### PR TITLE
Move require File.expand_path from rails_helper to spec_helper.rb

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 require 'shoulda/matchers'
 require 'capybara/rspec'
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,9 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require File.expand_path('../../config/environment', __FILE__)
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
RSpec test is back to work.

- spec/controllers - 3 failures
- spec/mailers/ - 0 failures
- spec/models - 4 failures
- spec/requests/ - 7 failures
- spec/routing/ - 0 failures
- spec/features/ - NOT CONFIGURED.

Need to be fixed in future patches.

Resolved #33 